### PR TITLE
show example of changing column width mid table

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -78,6 +78,7 @@ Pass options to individual columns through the options hash by using the display
 a skinny email column, set the width explicitly:
 
   tp User.all, :email => {:width => 12}
+  tp User.all, :id, {:email => {:width => 12}}, :age
 
 Available column options:
 


### PR DESCRIPTION
Just a one liner to show how to set column widths when not the last column.
Following 

```
tp User.all, :email => {:width => 12}
```

I tried to do the following but it is not valid ruby.

```
tp User.all, :id, :email => {:width => 12}, :age
```

To fix this you need to wrap the whole column in {}

```
tp User.all, :id, {:email => {:width => 12}}. :age
```
