### PR TITLE
Changes to work with Sequel models

### DIFF
--- a/features/adding_columns.feature
+++ b/features/adding_columns.feature
@@ -13,9 +13,9 @@ Feature: Adding columns
     And table_print Foo, {:include => ["blog.author", "blog.title"]}
     Then the output should contain
     """
-    HERP | BLOG.AUTHOR | BLOG.TITLE
-    -------------------------------
-    derp | Ryan        | post!
+    | HERP | BLOG.AUTHOR | BLOG.TITLE |
+    -----------------------------------
+    | derp | Ryan        | post!      |
     """
 
   Scenario: Providing a named proc
@@ -27,9 +27,9 @@ Feature: Adding columns
     And table_print Blog, {:wombat => {:display_method => lambda{|blog| blog.author.gsub(/[aeiou]/, "").downcase}}}
     Then the output should contain
     """
-    WOMBAT
-    ------
-    ryn
+    | WOMBAT |
+    ----------
+    | ryn    |
     """
   Scenario: Providing a named proc without saying 'display_method', eg :foo => lambda{}
     Given a class named Blog
@@ -40,9 +40,9 @@ Feature: Adding columns
     And table_print Blog, {:wombat => lambda{|blog| blog.author.gsub(/[aeiou]/, "").downcase}}
     Then the output should contain
     """
-    WOMBAT
-    ------
-    ryn
+    | WOMBAT |
+    ----------
+    | ryn    |
     """
   Scenario: Using a proc as a filter (ie, overriding an existing column with a proc)
 

--- a/features/configuring_output.feature
+++ b/features/configuring_output.feature
@@ -9,9 +9,9 @@ Feature: Configuring output
     And table_print Blog, {:include => {:author => {:width => 40}}}
     Then the output should contain
     """
-    TITLE | AUTHOR                                  
-    ------------------------------------------------
-    post! | Ryan Ryan Ryan Ryan Ryan Ryan Ryan Ry... 
+    | TITLE | AUTHOR                                   |
+    ----------------------------------------------------
+    | post! | Ryan Ryan Ryan Ryan Ryan Ryan Ryan Ry... |
     """
   Scenario: Specifying configuration on a per-object basis
     Given a class named Blog
@@ -23,9 +23,9 @@ Feature: Configuring output
     And table_print Blog
     Then the output should contain
     """
-    TITLE
-    -----
-    post!
+    | TITLE |
+    ---------
+    | post! |
     """
   Scenario: Specifying configuration on a per-object basis with an included column
     Given a class named Blog
@@ -37,9 +37,9 @@ Feature: Configuring output
     And table_print Blog
     Then the output should contain
     """
-    TITLE | AUTHOR | FOOBAR
-    -----------------------
-    post! | Ryan   | post!
+    | TITLE | AUTHOR | FOOBAR |
+    ---------------------------
+    | post! | Ryan   | post!  |
     """
   Scenario: Applying a formatter
   Scenario: Setting a column name
@@ -51,7 +51,7 @@ Feature: Configuring output
     And table_print Blog, {:wombat => {:display_method => :author}}
     Then the output should contain
     """
-    WOMBAT
-    ------
-    Ryan
+    | WOMBAT |
+    ----------
+    | Ryan   |
     """

--- a/features/excluding_columns.feature
+++ b/features/excluding_columns.feature
@@ -8,9 +8,9 @@ Feature: Excluding columns
     And table_print Blog, {:except => :title}
     Then the output should contain
     """
-    AUTHOR
-    ------
-    Ryan
+    | AUTHOR |
+    ----------
+    | Ryan   |
     """
 
   Scenario: By specifying columns
@@ -22,7 +22,7 @@ Feature: Excluding columns
     And table_print Blog, [:author, :url]
     Then the output should contain
     """
-    AUTHOR | URL              
-    --------------------------
-    Ryan   | http://google.com
+    | AUTHOR | URL               |
+    ------------------------------
+    | Ryan   | http://google.com |
     """

--- a/features/printing_hash.feature
+++ b/features/printing_hash.feature
@@ -9,11 +9,11 @@ Feature: Printing hash
     When I table_print data
     Then the output should contain
     """
-    TITLE        | AUTHOR
-    ---------------------
-    First post!  | Ryan  
-    Second post! | John  
-    Third post!  | Peter
+    | TITLE        | AUTHOR |
+    -------------------------
+    | First post!  | Ryan   |
+    | Second post! | John   |
+    | Third post!  | Peter  |
     """
 
   Scenario: A lambda column
@@ -25,11 +25,11 @@ Feature: Printing hash
     When I table_print data, [:include => {:two => lambda{|hash| hash[:author]*2}}]
     Then the output should contain
     """
-    TITLE        | AUTHOR | TWO       
-    ----------------------------------
-    First post!  | Ryan   | RyanRyan  
-    Second post! | John   | JohnJohn  
-    Third post!  | Peter  | PeterPeter
+    | TITLE        | AUTHOR | TWO        |
+    --------------------------------------
+    | First post!  | Ryan   | RyanRyan   |
+    | Second post! | John   | JohnJohn   |
+    | Third post!  | Peter  | PeterPeter |
     """
 
   Scenario: A method on the object
@@ -41,11 +41,11 @@ Feature: Printing hash
     When I table_print data, [:include => :size]
     Then the output should contain
     """
-    TITLE        | AUTHOR | SIZE
-    ----------------------------
-    First post!  | Ryan   | 2   
-    Second post! | John   | 2   
-    Third post!  | Peter  | 2   
+    | TITLE        | AUTHOR | SIZE |
+    --------------------------------
+    | First post!  | Ryan   | 2    |
+    | Second post! | John   | 2    |
+    | Third post!  | Peter  | 2    |
     """
 
 

--- a/features/sensible_defaults.feature
+++ b/features/sensible_defaults.feature
@@ -21,9 +21,9 @@ Feature: Sensible defaults
     And table_print Foo::Blog
     Then the output should contain
     """
-    TITLE       | AUTHOR
-    --------------------
-    First post! | Ryan
+    | TITLE       | AUTHOR |
+    ------------------------
+    | First post! | Ryan   |
     """
 
   Scenario: An array of objects
@@ -42,11 +42,11 @@ Feature: Sensible defaults
     And table_print blog.posts
     Then the output should contain
     """
-    TITLE        | AUTHOR
-    ---------------------
-    First post!  | Ryan  
-    Second post! | Ryan  
-    Third post!  | Ryan
+    | TITLE        | AUTHOR |
+    -------------------------
+    | First post!  | Ryan   |
+    | Second post! | Ryan   |
+    | Third post!  | Ryan   |
     """
 
   Scenario: Nested objects
@@ -62,10 +62,10 @@ Feature: Sensible defaults
     When I table_print Blog, [:id, "comments.id", "comments.username"]
     Then the output should contain
     """
-    ID | COMMENTS.ID | COMMENTS.USERNAME
-    ------------------------------------
-    1  | 1           | chris            
-       | 2           | joe
+    | ID | COMMENTS.ID | COMMENTS.USERNAME |
+    ----------------------------------------
+    | 1  | 1           | chris             |
+    |    | 2           | joe               |
     """
 
   Scenario: An object with column info (like an ActiveRecord object)
@@ -80,7 +80,7 @@ Feature: Sensible defaults
     And table_print Blog
     Then the output should contain
     """
-    TITLE      
-    -----------
-    First post!
+    | TITLE       |
+    ---------------
+    | First post! |
     """

--- a/features/support/step_definitions/steps.rb
+++ b/features/support/step_definitions/steps.rb
@@ -69,6 +69,7 @@ Then /^the output should contain$/ do |string|
     output << line
   end
   @r.close
+  puts output
 
   output.zip(string.split("\n")).each do |actual, expected|
     actual.gsub(/\s/m, "").split(//).sort.join.should == expected.gsub(" ", "").split(//).sort.join

--- a/lib/table_print.rb
+++ b/lib/table_print.rb
@@ -12,6 +12,7 @@ require 'table_print/returnable'
 module TablePrint
   class Printer
 
+    # Convenience method to call table_print() method (which is an instance method) on the class
     def self.table_print(data, options={})
       p = new(data, options)
       p.table_print
@@ -23,6 +24,7 @@ module TablePrint
       @columns = nil
     end
 
+    # Constructs string output in a tabular form which can be printed
     def table_print
       return "No data." if @data.empty?
       group = TablePrint::RowGroup.new
@@ -41,18 +43,24 @@ module TablePrint
       [group.header, group.horizontal_separator, group.format].join("\n")
     end
 
+    # Returns the columns for the stored data
     def columns
       return @columns if @columns
-      defaults = TablePrint::Printable.default_display_methods(@data.first)
-      c = TablePrint::ConfigResolver.new(@data.first.class, defaults, @options)
+      default_columns = TablePrint::Printable.default_display_methods(@data.first)
+      c = TablePrint::ConfigResolver.new(@data.first.class, default_columns, @options)
       @columns = c.columns
     end
+
   end
 end
+
 
 def tp(data=Class, *options)
   start = Time.now
   printer = TablePrint::Printer.new(data, options)
+
+  puts "\n"
   puts printer.table_print unless data.is_a? Class
+  puts "\n"
   TablePrint::Returnable.new(Time.now - start) # we have to return *something*, might as well be execution time.
 end

--- a/lib/table_print/config.rb
+++ b/lib/table_print/config.rb
@@ -10,6 +10,8 @@ module TablePrint
 
     @@klasses = {}
 
+    # This method either sets a config for a given class (klass, config)
+    # OR if klass is not a Class, then assume that we call a method on this class and pass in the value
     def self.set(klass, val)
       if klass.is_a? Class
         @@klasses[klass] = val  # val is a hash of column options
@@ -18,6 +20,7 @@ module TablePrint
       end
     end
 
+    # Returns the config for this class from the collection of stored configs for classes
     def self.for(klass)
       @@klasses.fetch(klass) {}
     end

--- a/lib/table_print/config_resolver.rb
+++ b/lib/table_print/config_resolver.rb
@@ -1,5 +1,10 @@
+
+# A class that incorporates various configs/options from the user into the final output given the data
+
 module TablePrint
   class ConfigResolver
+
+    # Initialize with the class of data we are process, default columns and user options
     def initialize(klass, default_column_names, *options)
       @column_hash = {}
 

--- a/lib/table_print/printable.rb
+++ b/lib/table_print/printable.rb
@@ -1,8 +1,17 @@
 module TablePrint
   module Printable
     # Sniff the data class for non-standard methods to use as a baseline for display
+    # If class has a .columns() or a .keys() use it over methods
     def self.default_display_methods(target)
-      return target.class.columns.collect(&:name) if target.class.respond_to? :columns
+       if target.class.respond_to? :columns
+         return target.class.columns.collect do |column|
+           if column.respond_to? :name
+             column.name
+           else
+             column
+           end
+         end
+       end
       
       return target.keys if target.is_a? Hash
 
@@ -10,14 +19,15 @@ module TablePrint
       target.methods.each do |method_name|
         method = target.method(method_name)
 
+        # Check that this method is not an inherited method and that it does not require any arguments
         if method.owner == target.class
-          if method.arity == 0 #
+          if method.arity == 0
             methods << method_name.to_s
           end
         end
       end
 
-      methods.delete_if { |m| m[-1].chr == "!" } # don't use dangerous methods
+      methods.delete_if { |m| m[-1].chr == "!" } # Don't use dangerous methods
       methods
     end
   end

--- a/lib/table_print/row_group.rb
+++ b/lib/table_print/row_group.rb
@@ -71,7 +71,7 @@ module TablePrint
         f.format(column.name)
       end
 
-      padded_names.join(" | ").upcase
+      ["| ", padded_names.join(" | "), " |"].join.upcase
     end
 
     def add_formatter(name, formatter)
@@ -108,11 +108,11 @@ module TablePrint
     end
 
     # TODO: rename this to_s
-    def format
+    def format(append_bars=true)
       rows = @children
       rows = @children[1..-1] if @skip_first_row
       rows ||= []
-      rows = rows.collect { |row| row.format }.join("\n")
+      rows = rows.collect { |row| row.format(append_bars) }.join("\n")
 
       return nil if rows.length == 0
       rows
@@ -169,13 +169,14 @@ module TablePrint
       self
     end
 
-    def format
+    def format(append_bars=true)
       column_names = columns.collect(&:name)
 
       output = [column_names.collect { |name| apply_formatters(name, @cells[name]) }.join(" | ")]
-      output.concat @children.collect { |g| g.format }
+      output.concat @children.collect { |g| g.format(false)}
 
-      output.join("\n")
+      output = output.collect {|o| append_bars ? "| #{o} |" : o }
+      output = output.join("\n")
     end
 
     def absorb_children(column_names, rollup)

--- a/lib/table_print/version.rb
+++ b/lib/table_print/version.rb
@@ -1,4 +1,4 @@
 module TablePrint
-  VERSION = "1.1.4"
+  VERSION = "1.2.0"
 end
 

--- a/spec/row_group_spec.rb
+++ b/spec/row_group_spec.rb
@@ -95,19 +95,19 @@ describe RowRecursion do
   describe "#horizontal_separator" do
     it "returns hyphens equal to the table width" do
       child.set_cell_values(:title => 'foobar')
-      child.horizontal_separator.should == '------'
+      child.horizontal_separator.should == '----------'
     end
 
     it "matches the header width" do
       child.set_cell_values(:title => 'foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar')
-      child.horizontal_separator.should == '------------------------------' # 30 hyphens
+      child.horizontal_separator.should == '----------------------------------' # 34 hyphens
     end
   end
 
   describe "#header" do
     it "returns the column names, padded to the proper width, separated by the | character" do
       child.set_cell_values(:title => 'first post', :author => 'chris', :subtitle => 'first is the worst')
-      compare_rows(child.header, "AUTHOR | SUBTITLE           | TITLE     ")
+      compare_rows(child.header, "| AUTHOR | SUBTITLE           | TITLE      |")
     end
   end
 end
@@ -131,16 +131,16 @@ def compare_rows(actual_rows, expected_rows)
 end
 
 describe TablePrint::Row do
-  let(:row) { Row.new.set_cell_values({'title' => "wonky", 'author' => "bob jones", 'pub_date' => "2012"}) }
+  let(:row) { Row.new.set_cell_values({'title' => " wonky", 'author' => "bob jones", 'pub_date' => "2012"}) }
 
   describe "#format" do
     it "formats the row with padding" do
-      compare_rows(row.format, "wonky | bob jones | 2012    ")
+      compare_rows(row.format, "| wonky | bob jones | 2012      |")
     end
 
     it "also formats the children" do
       row.add_child(RowGroup.new.add_child(Row.new.set_cell_values(:title => "wonky2", :author => "bob jones2", :pub_date => "20122")))
-      compare_rows(row.format, "wonky  | bob jones  | 2012    \nwonky2 | bob jones2 | 20122   ")
+      compare_rows(row.format, "| wonky  | bob jones  | 2012     |\n|  wonky2 | bob jones2 | 20122   |")
     end
   end
 


### PR DESCRIPTION
Changing formatting for the table so that each row is preceded and end swith a "|" (bar) Also making gem compatible with Sequel right now its only compatible with ActiveRecord

I have bumped the minor version because I have changed formatting of the output. According to semantic versioning, it seemed like a good idea to bump the minor but correct me if I am mistaken. 
