### PR TITLE
Added support for colorized values

### DIFF
--- a/lib/table_print/formatter.rb
+++ b/lib/table_print/formatter.rb
@@ -25,7 +25,7 @@ module TablePrint
     end
 
     def format(value)
-      padding = width - value.to_s.each_char.collect{|c| c.bytesize == 1 ? 1 : 2}.inject(0, &:+)
+      padding = width - strip_escape(value.to_s).each_char.collect{|c| c.bytesize == 1 ? 1 : 2}.inject(0, &:+)
       truncate(value) + (padding < 0 ? '' : " " * padding)
     end
 
@@ -34,9 +34,13 @@ module TablePrint
       return "" unless value
 
       value = value.to_s
-      return value unless value.length > width
+      return value unless strip_escape(value).length > width
 
       "#{value[0..width-4]}..."
+    end
+
+    def strip_escape(value)
+      value.gsub(%r{\e[^m]*m}, '')
     end
   end
 end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -53,6 +53,10 @@ describe TablePrint::FixedWidthFormatter do
       @f.format("1234567890123456").should == "1234567..."
     end
 
+    it "truncate colorized values correctly" do 
+      @f.format("\e[0;31;49masdf\e[0m").should == "\e[0;31;49masdf\e[0m      "
+    end
+
     it "uses an empty string in place of nils" do
       @f.format(nil).should == "          "
     end


### PR DESCRIPTION
When I wanted to colorize some values, I used the following formatter

``` ruby
  class ColorFormatter
      def initialize(color)
        @color = color
      end
      def format(data)
        HighLine.color(data.to_s, @color)
      end
    end
```

The cells were then padded incorrectly, because the unprintable escape sequence that sets the color was counted in the length of the value. this patch is stripping the unprintable stuff during padding.
