### PR TITLE
Make TablePrint compatible with Sequel models

### DIFF
--- a/lib/table_print/printable.rb
+++ b/lib/table_print/printable.rb
@@ -2,8 +2,8 @@ module TablePrint
   module Printable
     # Sniff the data class for non-standard methods to use as a baseline for display
     def self.default_display_methods(target)
-      return target.class.columns.collect(&:name) if target.class.respond_to? :columns
-
+      # Sequel columns are just symbols
+      return target.class.columns.collect{|c| c.respond_to?(:name) ? c.name : c } if target.class.respond_to? :columns
       # eg mongoid
       return target.fields.keys if target.respond_to? :fields and target.fields.is_a? Hash
 


### PR DESCRIPTION
`Sequel::Model.columns` is array of ids, but TablePrint::Printable was trying to call `#name` on them
