### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.0.0
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2
   - ree
 


### PR DESCRIPTION
Rubinius 2.x supports Ruby 2.1. Using 'rbx-2' will test against the most current Rubinius 2.x release, presently 2.2.7 (but Travis is still running 2.2.6 unfortunately).
