### PR TITLE
Add align column attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ doc
 # jeweler generated
 pkg
 
+# ignore built gems
+*.gem
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore

--- a/README.rdoc
+++ b/README.rdoc
@@ -79,6 +79,7 @@ a skinny email column, set the width explicitly:
   tp User.all, :email => {:width => 12}
   tp User.all, :id, {:email => {:width => 12}}, :age
 
+
 Available column options:
 
 * *display_method* - string/symbol/proc - used to populate the column. Can be a method name or a proc. See below.
@@ -86,6 +87,7 @@ Available column options:
 * *time_format* - string - passed to strftime[http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-strftime], only affects time columns
 * *width* - integer - how wide you want your column.
 * *display_name* - string - useful if you want spaces in your column name
+* *align* - symbol or string - indicate column alignment: `:left`, `:center`, `:right`.  Default is `:left`.
 
 ==== Display method
 
@@ -107,16 +109,37 @@ Make sure to add curly braces if you have more than one column with a lambda or 
 
   tp User.all, :email, { daily_payment: lambda { |u| u.monthly_payment / 30} }, :monthly_payment, { yearly_payment: lambda { |u| u.monthly_payment * 12} }
 
+==== Column Helper Methods
+
+There are helper methods to build the column option hashes:
+
+* `COLUMN.as(LABEL)` - use LABEL for the COLUMN header
+* `COLUMN.width(W)`  - set the COLUMN width to W
+* `COLUMN.right`     - set the COLUMN.align to :right
+* `COLUMN.left`      - set the COLUMN.align to :left
+* `COLUMN.center`    - set the COLUMN.align to :center
+
+These helper methods can be chained, and can be in any order.
+
+Example:
+
+  tp User.all :id.as('Id').right, :email.as('Email Address').width(12), :age.right
+
 ==== Column formatters
 
-Similar to a lambda column, you can use a column formatter to reuse code across prints. Any object with a 'format' method
-can be used to filter a column. This could also be used for coloring output.
+Similar to a lambda column, you can use a column formatter to reuse code across
+prints. Any object with a 'format' method can be used to filter a column. This
+could also be used for coloring output.
+
+For example:
 
   class NoNewlineFormatter
     def format(value)
       value.to_s.gsub(/\r\n/, " ")
     end
   end
+
+This example is actually one of the formatters applied to all columns.
 
   tp User.all, :bio => {:formatters => [NoNewlineFormatter.new]} # strip newlines from user bios
 
@@ -134,7 +157,7 @@ method to send table_print output directly into your <pre> tag:
 Use tp.set and tp.clear to set options on a class-by-class basis.
 
   tp.set User, :id, :email # now whenever you print users, the only columns shown will be id and email
-  
+
   > tp User.first
   ID | EMAIL
   ---|------------
@@ -165,7 +188,7 @@ You can also set global options:
   tp.set :max_width, 10 # columns won't exceed 10 characters
   tp.set :time_format, "%Y" # date columns will only show the year
   tp.set :capitalize_headers, false # don't capitalize column headers
-  
+
 You can redirect output:
 
   f = File.open("users.txt", "w")
@@ -173,7 +196,7 @@ You can redirect output:
   tp User.all # written to users.txt instead of STDOUT
   tp.clear :io
   tp User.all # writing to STDOUT again
-  
+
 === Multibyte
 
 Unfortunately, the current approach to finding the width of multibyte strings is too slow. If you're going to be

--- a/Rakefile
+++ b/Rakefile
@@ -46,3 +46,10 @@ Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_files.include('README*')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
+
+task :console do
+  require 'pry'
+  require 'table_print'
+  ARGV.clear
+  Pry.start
+end

--- a/lib/table_print.rb
+++ b/lib/table_print.rb
@@ -7,6 +7,7 @@ require 'table_print/hash_extensions'
 require 'table_print/printable'
 require 'table_print/row_group'
 require 'table_print/returnable'
+require 'table_print/column_helpers'
 
 module TablePrint
   class Printer

--- a/lib/table_print/column.rb
+++ b/lib/table_print/column.rb
@@ -1,10 +1,11 @@
 module TablePrint
   class Column
     attr_reader :formatters
-    attr_accessor :name, :data, :time_format, :default_width
+    attr_accessor :name, :data, :time_format, :default_width, :align
 
     def initialize(attr_hash={})
       @formatters = []
+      @align ||= :left
       attr_hash.each do |k, v|
         self.send("#{k}=", v)
       end

--- a/lib/table_print/column_helpers.rb
+++ b/lib/table_print/column_helpers.rb
@@ -1,0 +1,144 @@
+# column_helpers.rb
+#
+#  OBJ.from(SRC)      -- set :display_method => SRC
+#  OBJ.as(LABEL)      -- set :display_name   => LABEL
+#  OBJ.width(W)       -- set :width => W
+#  OBJ.formatter(FMT) -- set :formatters => [ FMT ]
+#  OBJ.left(W)        -- set :align=>:left, :width=>W
+#  OBJ.right(W)       -- set :align=>:right, :width=>W
+#  OBJ.center(W)      -- set :align=>:center, :width=>W
+#  OBJ.as_num(W)      -- set :width => W, :formatter => [TP_NumFormat]
+#  OBJ.as_money(W)    -- set :width => W, :formatter => [TP_MoneyFormat]
+#
+#  OBJ.as(LABEL).width(w).as_num
+#
+# where OBJ can be a Symbol, String, or HASH (chained helpers)
+
+module TablePrint::ColumnHelpers
+
+  # tp Object, :building_id.as('Id')
+  # tp Object, 'building_id'.as('Id')
+  # tp Object, :building_id.width(4).as('Id')
+
+  refine Symbol do ; def as l ; { self => { :display_name => l }}                   ; end ; end
+  refine String do ; def as l ; self.intern.as(l)                                   ; end ; end
+  refine Hash   do ; def as l ; self.merge_column_attributes! self.keys.first.as(l) ; end ; end
+
+  # tp Object, :name.from(src)
+  # tp Object, 'name'.from(src)
+  # tp Object, :name.width(30).from(src)
+
+  refine Symbol do ; def from src ; { self => { :display_method => src } }                  ; end ; end
+  refine String do ; def from src ; self.intern.from(src)                                   ; end ; end
+  refine Hash   do ; def from src ; self.merge_column_attributes! self.keys.first.from(src) ; end ; end
+
+  # tp Object, :name.width(30)
+  # tp Object, 'name'.width(30)
+  # tp Object, :name.as('Building Name').width(30)
+
+  refine Symbol do ; def width w ; { self => { :width => w } }                            ; end ; end
+  refine String do ; def width w ; self.intern.width(w)                                   ; end ; end
+  refine Hash   do ; def width w ; self.merge_column_attributes! self.keys.first.width(w) ; end ; end
+
+  # tp Object, :name.left(5)
+  # tp Object, 'name'.right(10)
+  # tp Object, 'name'.center(20)
+  #
+  # tp Object, :name.align(:left)
+  # tp Object, :name.align(:left, 10)
+
+  refine Symbol do
+
+    def left   w=nil  ; self.align :left,   w ; end
+    def right  w=nil  ; self.align :right,  w ; end
+    def center w=nil  ; self.align :center, w ; end
+
+    def align how=:left, width=nil
+      if width.nil?
+        { self => { :align => how } }
+      else
+        { self => { :align => how, :width => width }}
+      end
+    end
+  end
+
+  refine String do
+    def left   w=nil ; self.align :left,   w ; end
+    def right  w=nil ; self.align :right,  w ; end
+    def center w=nil ; self.align :center, w ; end
+
+    def align how=:left, width=nil
+      self.intern.align how, width
+    end
+  end
+
+  refine Hash do
+    def left   w=nil ; self.align :left,   w ; end
+    def right  w=nil ; self.align :right,  w ; end
+    def center w=nil ; self.align :center, w ; end
+
+    def align how=:left, width=nil
+      self.merge_column_attributes! self.keys.first.align(how, width)
+    end
+  end
+
+  # tp Object, :name.formatter(FMT)
+  # tp Object, 'name'.formatter(FMT)
+  # tp Object, :name.as('MyName').formatter(FMT)
+
+  refine Symbol do ; def formatter fmt ; { self => { :formatters => Array(fmt) } }                    ; end ; end
+  refine String do ; def formatter fmt ; self.intern.formatter fmt                                    ; end ; end
+  refine Hash   do ; def formatter fmt ; self.merge_column_attributes! self.keys.first.formatter(fmt) ; end ; end
+
+  # tp Object, :name.as_num(width=nil)
+  # tp Object, 'name'.as_num(width=nil)
+  # tp Object, :name.as('MyName').as_num(width=nil)
+
+  refine Symbol do ; def as_num w=nil ; self.formatter(TablePrint::NumFormatter.new(w)).width(w) ; end ; end
+  refine String do ; def as_num w=nil ; self.intern.as_num w                                     ; end ; end
+  refine Hash   do ; def as_num w=nil ; self.merge_column_attributes! self.keys.first.as_num(w)  ; end ; end
+
+  # tp Object, :name.as_money(w=nil)
+  # tp Object, 'name'.as_money(w=nil)
+  # tp Object, :name.width(20).as_money(w=nil)
+
+  refine Symbol do ; def as_money w=nil ; self.formatter(TablePrint::MoneyFormatter.new(w)).width(w) ; end ; end
+  refine String do ; def as_money w=nil ; self.intern.as_money w                                     ; end ; end
+  refine Hash   do ; def as_money w=nil ; self.merge_column_attributes! self.keys.first.as_money(w)  ; end ; end
+
+  # merge_column_attributes -- merge a new HASH with the existing attributes
+  # hash.
+
+  refine Hash do
+    def merge_column_attributes! more
+      { self.keys.first => self.values.first.merge(more.values.first) }
+    end
+  end
+
+end # TablePrint::ColumnHelpers
+
+module TablePrint
+
+  class NumFormatter
+    attr_accessor :width
+    def initialize width=nil
+      @width = width
+    end
+    def format v
+      sprintf "%*d", @width || 4, v.to_i
+    end
+  end
+
+  class MoneyFormatter
+    attr_accessor :width
+    def initialize width=nil
+      @width = width
+    end
+    def format v
+      sprintf "$%*.2f", @width.nil? ? 0 : @width - 1, v.to_f
+    end
+  end
+
+end # module TablePrint
+
+# end column_helpers.rb

--- a/lib/table_print/formatter.rb
+++ b/lib/table_print/formatter.rb
@@ -19,14 +19,24 @@ module TablePrint
 
   class FixedWidthFormatter
     attr_accessor :width
+    attr_accessor :align
 
-    def initialize(width)
+    def initialize(width, align=:left)
       self.width = width
+      self.align = align
     end
 
     def format(value)
-      padding = width - length(value.to_s)
-      truncate(value) + (padding < 0 ? '' : " " * padding)
+      case align
+      when :left, 'left', 'l'
+        truncate(value).ljust(width)
+      when :right, 'right', 'r'
+        truncate(value).rjust(width)
+      when :center, 'center', 'c'
+        truncate(value).center(width)
+      else
+        truncate(value).ljust(width)
+      end
     end
 
     private

--- a/lib/table_print/row_group.rb
+++ b/lib/table_print/row_group.rb
@@ -69,7 +69,7 @@ module TablePrint
 
     def header
       padded_names = columns.collect do |column|
-        f = FixedWidthFormatter.new(column.width)
+        f = FixedWidthFormatter.new(column.width, :center)
         f.format(column.name)
       end
 
@@ -218,7 +218,7 @@ module TablePrint
 
       formatters << TimeFormatter.new(column.time_format)
       formatters << NoNewlineFormatter.new
-      formatters << FixedWidthFormatter.new(column_for(column_name).width)
+      formatters << FixedWidthFormatter.new(column.width, column.align)
 
       # successively apply the formatters for a column
       formatters.inject(value) do |value, formatter|

--- a/lib/table_print/version.rb
+++ b/lib/table_print/version.rb
@@ -1,4 +1,4 @@
 module TablePrint
-  VERSION = "1.5.3"
+  VERSION = "1.6.0"
 end
 

--- a/spec/column_helpers_spec.rb
+++ b/spec/column_helpers_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+include TablePrint
+
+using TablePrint::ColumnHelpers
+
+describe TablePrint::ColumnHelpers do
+  # let(:c) { Column.new(:data => ["Once upon a time", "there was a dark and stormy night"], :name => :tagline) }
+
+  context "when using the .as helper" do
+    it "works on symbol names, and returns the hash with :display_name" do
+      :field.as('Field Name').should ==
+        { :field => { :display_name => 'Field Name' } }
+    end
+    it "works on strings, returning the hash with the :display_name" do
+      'field'.as('Field Name').should ==
+        { :field => { :display_name => 'Field Name' } }
+    end
+    it "works on hashes, returning the merged hash with the :display_name" do
+      :field.width(10).as('Field Name').should ==
+        { :field => { :width => 10, :display_name => 'Field Name' } }
+    end
+  end
+
+  context "when using the .from helper" do
+    it "works on symbol names, and returns the hash with :display_method" do
+      :field.from('some_other_field').should ==
+        { :field => { :display_method => 'some_other_field' }}
+    end
+    it "works on string names and returns the hash with :display_method" do
+      'field'.from('some_other_field').should ==
+        { :field => { :display_method => 'some_other_field' }}
+    end
+    it "works on hashes and returns the merged hash with :display_method" do
+      :field.as('Field Name').from('some_other_field').should ==
+        { :field => { :display_name => 'Field Name', :display_method => 'some_other_field' }}
+    end
+  end
+
+  context "when using the .width helper" do
+    it "works on symbol names, and returns the hash with :width set" do
+      :field.width(10).should == { :field => { :width => 10 } }
+    end
+    it "works on string names and returns the hash with the :width set" do
+      'field'.width(10).should == { :field => { :width => 10 } }
+    end
+    it "works on hashes and returns the merged hash with the :width set" do
+      :field.as('Field Name').width(10) ==
+        { :field => { :display_name => 'Field Name', :width => 10 } }
+    end
+  end
+
+  context "when using the :align helpers without a width spec" do
+    it ":left returns the hash with :align set to :left" do
+      :field.left.should             == { :field => {               :align => :left }}
+      'field'.left.should            == { :field => {               :align => :left }}
+      :field.width(10).left.should   == { :field => { :width => 10, :align => :left }}
+    end
+    it ":right returns the hash with :align set to :right" do
+      :field.right.should            == { :field => {               :align => :right }}
+      'field'.right.should           == { :field => {               :align => :right }}
+      :field.width(10).right.should  == { :field => { :width => 10, :align => :right }}
+    end
+    it ":center returns the hash with :align set to :center" do
+      :field.center.should           == { :field => {               :align => :center }}
+      'field'.center.should          == { :field => {               :align => :center }}
+      :field.width(10).center.should == { :field => { :width => 10, :align => :center }}
+    end
+  end
+
+  context "when using the :align helpers with a width spec" do
+    it ":left returns the hash with both :align and :width set" do
+      :field.left(8).should              == { :field => {                         :align => :left, :width => 8 }}
+      'field'.left(9).should             == { :field => {                         :align => :left, :width => 9 }}
+      :field.as('foo').left(10).should   == { :field => { :display_name => 'foo', :align => :left, :width => 10 }}
+    end
+    it ":right returns the hash with both :align and :width set" do
+      :field.right(8).should             == { :field => {                         :align => :right, :width => 8 }}
+      'field'.right(9).should            == { :field => {                         :align => :right, :width => 9 }}
+      :field.as('bar').right(10).should  == { :field => { :display_name => 'bar', :align => :right, :width => 10 }}
+    end
+    it ":center returns the hash with both :align and :width set" do
+      :field.center(8).should            == { :field => {                         :align => :center, :width => 8 }}
+      'field'.center(9).should           == { :field => {                         :align => :center, :width => 9 }}
+      :field.as('baz').center(10).should == { :field => { :display_name => 'baz', :align => :center, :width => 10 }}
+    end
+  end
+
+  context "when using the .as_num helper without a width spec" do
+    it "sets the column spec hash with a custom formatter for numbers" do
+      f = :field.as_num
+      fmt = f[:field][:formatters].first
+      fmt.to_s.should =~ /TablePrint::NumFormatter/
+    end
+    it "formats numbers with a default width of 4" do
+      f = :field.as_num
+      fmt = f[:field][:formatters].first
+      fmt.format(123).should == ' 123'
+    end
+  end
+
+  context "when using the .as_num helper with a width spec" do
+    it "sets the column spec hash with the NumFormatter and the width spec" do
+      f = :field.as_num(10)
+      fmt = f[:field][:formatters].first
+      fmt.to_s.should =~ /TablePrint::NumFormatter/
+      f[:field][:width].should == 10
+      fmt.format(123).should == '       123'
+    end
+  end
+
+  context "when using the .as_money helper without a width spec" do
+    it "sets the column spec hash with a custom formatter for money" do
+      f = :field.as_money
+      fmt = f[:field][:formatters].first
+      fmt.to_s.should =~ /TablePrint::MoneyFormatter/
+      fmt.format(123.45).should == '$123.45'
+    end
+  end
+
+  context "when using the .as_money helper with a width spec" do
+    it "sets the column spec hash with the MoneyFormatter and the width spec" do
+      f = :field.as_money(10)
+      fmt = f[:field][:formatters].first
+      fmt.to_s.should =~ /TablePrint::MoneyFormatter/
+      f[:field][:width].should == 10
+      fmt.format(123.45).should == '$   123.45'
+    end
+  end
+
+end

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -90,4 +90,25 @@ describe Column do
       end
     end
   end
+
+  describe "#align" do
+    context "when no :align attribute is given" do
+      let(:c) {Column.new(:data => ["Once upon a time", "there was a dark and stormy night"], :name => :tagline)}
+      it "should default to :left" do
+        c.align.should == :left
+      end
+    end
+    context "when :align :right is given" do
+      let(:c) {Column.new(:data => ["Once upon a time", "there was a dark and stormy night"], :name => :tagline, :align => :right)}
+      it "should return the correct value of :right" do
+        c.align.should == :right
+      end
+    end
+    context "when :align :center is given" do
+      let(:c) {Column.new(:data => ["Once upon a time", "there was a dark and stormy night"], :name => :tagline, :align => :center)}
+      it "should return the correct value of :center" do
+        c.align.should == :center
+      end
+    end
+  end
 end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -62,3 +62,71 @@ describe TablePrint::FixedWidthFormatter do
     end
   end
 end
+
+describe TablePrint::FixedWidthFormatter do
+  before(:each) do
+    @f = TablePrint::FixedWidthFormatter.new(10, :right)
+  end
+
+  describe "#format" do
+    it "pads a short field to the specified width on the right" do
+      @f.format("asdf").should == "      asdf"
+    end
+
+    it "truncates long fields with periods" do
+      @f.format("1234567890123456").should == "1234567..."
+    end
+
+    it "uses an empty string in place of nils" do
+      @f.format(nil).should == "          "
+    end
+
+    it "turns objects into strings before trying to format them" do
+      @f.format(123).should == "       123"
+    end
+  end
+end
+
+describe TablePrint::NumFormatter do
+  before(:each) do
+    @f = TablePrint::NumFormatter.new(8)
+  end
+
+  describe "#format" do
+    it "pads a number to the right" do
+      @f.format(123).should ==  "     123"
+      @f.format(1234).should == "    1234"
+    end
+    it "sets the width of the column" do
+      @f.width.should == 8
+    end
+    it "allows the width to be set" do
+      @f.width = 10
+      @f.width.should == 10
+      @f.format(1234).should == "      1234"
+    end
+  end
+end
+
+describe TablePrint::MoneyFormatter do
+  before(:each) do
+    @f = TablePrint::MoneyFormatter.new(8)
+  end
+
+  describe "#format" do
+    it "pads a decimal to the right" do
+      @f.format(123).should     == "$ 123.00"
+      @f.format(1234).should    == "$1234.00"
+      @f.format(1234.56).should == "$1234.56"
+    end
+    it "sets the width of the column" do
+      @f.width.should == 8
+    end
+    it "allows the width to be set" do
+      @f.width = 10
+      @f.width.should == 10
+      @f.format(1234).should == "$  1234.00"
+    end
+  end
+
+end

--- a/table_print.gemspec
+++ b/table_print.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/table_print/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.name                = "table_print"
 
-  gem.authors             = ["Chris Doyle"]
-  gem.email               = ["archslide@gmail.com"]
+  gem.authors             = ["Chris Doyle", "Alan Stebbens"]
+  gem.email               = ["archslide@gmail.com", "aks@stebbens.org"]
   gem.email               = "archslide@gmail.com"
 
   gem.description         = "TablePrint turns objects into nicely formatted columns for easy reading. Works great in rails console, works on pure ruby objects, autodetects columns, lets you traverse ActiveRecord associations. Simple, powerful."
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'cat', '~> 0.2.1'
   gem.add_development_dependency 'cucumber', '~> 1.2.1'
   gem.add_development_dependency 'rspec', '~> 2.11.0'
-  gem.add_development_dependency 'rake', '~> 0.9.2'
+  gem.add_development_dependency 'rake', '~> 10.4.2'
 end

--- a/table_print.gemspec
+++ b/table_print.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'cucumber', '~> 1.2.1'
   gem.add_development_dependency 'rspec', '~> 2.11.0'
   gem.add_development_dependency 'rake', '~> 10.4.2'
+  gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
First, thanks for a nice table formatter.

Second, I've added some column "helper" functions to make the `tp` argument hashes easier to build.  These are the in `column_helpers.rb` file.  There are some changes in the other files to support the new `:align` attribute.

I've also improved the formatters to support right, and center alignment for column specs.

specs & docs updated too.

feedback welcome.