### PR TITLE
Add support for column min width and fixed width.

### DIFF
--- a/features/configuring_output.feature
+++ b/features/configuring_output.feature
@@ -13,6 +13,21 @@ Feature: Configuring output
     ------|-----------------------------------------
     post! | Ryan Ryan Ryan Ryan Ryan Ryan Ryan Ry... 
     """
+
+  Scenario: Setting a minimum width for an individual column
+    Given a class named Blog
+
+    Given Blog has attributes title, author
+
+    When I instantiate a Blog with {:title => "post!", :author => 'Ryan Ryan'}
+    And table_print Blog, {:include => {:author => {:min_width => 40}}}
+    Then the output should contain
+    """
+    TITLE | AUTHOR                                  
+    ------|-----------------------------------------
+    post! | Ryan Ryan                                
+    """
+
   Scenario: Specifying configuration on a per-object basis
     Given a class named Blog
 

--- a/features/configuring_output.feature
+++ b/features/configuring_output.feature
@@ -23,8 +23,36 @@ Feature: Configuring output
     And table_print Blog, {:include => {:author => {:min_width => 40}}}
     Then the output should contain
     """
-    TITLE | AUTHOR                                  
+    TITLE | AUTHOR
     ------|-----------------------------------------
+    post! | Ryan Ryan
+    """
+
+  Scenario: Setting a fixed width for an individual column, when data width is greater than fixed width
+    Given a class named Blog
+
+    Given Blog has attributes title, author
+
+    When I instantiate a Blog with {:title => "post!", :author => 'Ryan Ryan Ryan Ryan Ryan Ryan Ryan'}
+    And table_print Blog, {:include => {:author => {:fixed_width => 15}}}
+    Then the output should contain
+    """
+    TITLE | AUTHOR
+    ------|----------------
+    post! | Ryan Ryan Ry...
+    """
+
+  Scenario: Setting a fixed width for an individual column, when data width is less than fixed width
+    Given a class named Blog
+
+    Given Blog has attributes title, author
+
+    When I instantiate a Blog with {:title => "post!", :author => 'Ryan Ryan'}
+    And table_print Blog, {:include => {:author => {:fixed_width => 15}}}
+    Then the output should contain
+    """
+    TITLE | AUTHOR
+    ------|----------------
     post! | Ryan Ryan                                
     """
 

--- a/lib/table_print/column.rb
+++ b/lib/table_print/column.rb
@@ -1,7 +1,7 @@
 module TablePrint
   class Column
     attr_reader :formatters
-    attr_accessor :name, :data, :time_format, :default_width, :min_width
+    attr_accessor :name, :data, :time_format, :default_width, :min_width, :fixed_width
 
     def initialize(attr_hash={})
       @formatters = []
@@ -48,6 +48,8 @@ module TablePrint
     end
 
     def width
+      return fixed_width if fixed_width
+
       width = [(default_width || max_width), data_width].min
       [(min_width || 0), width].max
     end

--- a/lib/table_print/column.rb
+++ b/lib/table_print/column.rb
@@ -1,7 +1,7 @@
 module TablePrint
   class Column
     attr_reader :formatters
-    attr_accessor :name, :data, :time_format, :default_width
+    attr_accessor :name, :data, :time_format, :default_width, :min_width
 
     def initialize(attr_hash={})
       @formatters = []
@@ -48,7 +48,8 @@ module TablePrint
     end
 
     def width
-      [(default_width || max_width), data_width].min
+      width = [(default_width || max_width), data_width].min
+      [(min_width || 0), width].max
     end
 
     private


### PR DESCRIPTION
This pull request adds two things, support for min width and fixed width for columns.

## min_width
Useful, since the default_width is not reached if the data is more narrow than the specified default_width.

## fixed_width
When rendering large tables, calculating the column data widths takes a long time (easily overs 10 seconds). In those cases, specifiying fixed widths for the columns shortcuts the data width calculation and the rendering is snappy again.