### PR TITLE
Prevent Ruby shadowing outer local variable - value warning

### DIFF
--- a/lib/table_print/returnable.rb
+++ b/lib/table_print/returnable.rb
@@ -24,6 +24,6 @@ module TablePrint
 
     def inspect
       to_s
-     end
+    end
   end
 end

--- a/lib/table_print/row_group.rb
+++ b/lib/table_print/row_group.rb
@@ -221,8 +221,8 @@ module TablePrint
       formatters << FixedWidthFormatter.new(column_for(column_name).width)
 
       # successively apply the formatters for a column
-      formatters.inject(value) do |value, formatter|
-        formatter.format(value)
+      formatters.inject(value) do |inner_value, formatter|
+        formatter.format(inner_value)
       end
     end
 


### PR DESCRIPTION
row_group.rb:224: warning: shadowing outer local variable - value