### PR TITLE
Convert printer.message return value to string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby-18mode
   - jruby-19mode
 

--- a/lib/table_print.rb
+++ b/lib/table_print.rb
@@ -51,7 +51,10 @@ module TablePrint
 
     def message
       return "Printed with config" if configged?
-      Time.now - @start_time
+      (Time.now - @start_time).to_s
+      # the message is used to initiate Returnable
+      # whose argument is regarded in ruby 2.7.1 as string
+      # (ruby 2.7.1 calls ".includes?" method on this argument)
     end
 
     private

--- a/spec/table_print_spec.rb
+++ b/spec/table_print_spec.rb
@@ -25,8 +25,10 @@ describe TablePrint::Printer do
   end
 
   describe "message" do
-    it "defaults to the time the print took" do
-      Printer.new([]).message.should be_a Numeric
+    it "defaults to the time the print took, but in string" do
+      message = Printer.new([]).message
+      message.should be_a String
+      expect(message.to_f.to_s).to eq(message)
     end
 
     it "shows a warning if the printed objects have config" do

--- a/table_print.gemspec
+++ b/table_print.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths       = ["lib"]
 
   gem.add_development_dependency 'cat', '~> 0.2.1'
-  gem.add_development_dependency 'cucumber', '~> 1.2.1'
+  gem.add_development_dependency 'cucumber', '~> 2.4.0'
   gem.add_development_dependency 'rspec', '~> 2.11.0'
   gem.add_development_dependency 'rake', '~> 0.9.2'
 end


### PR DESCRIPTION
**Related issue**

closes #84 

**Changes**

- Converted printer.message return value to string, test updates

- Added ruby 2.7 in travis

- Updated cucumber dependency from 1.2 to 2.4



- [x]  I ran this code locally

* * *

Use
```
gem 'table_print', git: "git://github.com/julienemo/table_print.git", branch: "84_bug_no_method_error_in_ruby_2.7.1"
```
in `Gemfile` til merge